### PR TITLE
fix(libra): resolve LogArgs import error and clippy warnings

### DIFF
--- a/aria/contents/docs/libra/command/log/index.mdx
+++ b/aria/contents/docs/libra/command/log/index.mdx
@@ -22,6 +22,8 @@ List commits that are reachable by current local branch. The order is from the l
 
 -   `-n`, `--number <NUMBER>`
     Limit the number of output
+-   `--oneline`
+    Shorthand for `--pretty=oneline --abbrev-commit`. Display each commit as a single line with abbreviated commit hash (7 characters) and commit message first line only.
 -   `-h`, `--help`
     Print help
 

--- a/libra/tests/command/mod.rs
+++ b/libra/tests/command/mod.rs
@@ -4,7 +4,7 @@ use libra::command::branch::BranchArgs;
 use libra::command::get_target_commit;
 use libra::command::init::init;
 use libra::command::init::InitArgs;
-use libra::command::log::get_reachable_commits;
+use libra::command::log::{get_reachable_commits, LogArgs};
 use libra::command::save_object;
 use libra::command::status::changes_to_be_staged;
 use libra::command::switch::{self, check_status, SwitchArgs};


### PR DESCRIPTION
描述
修复libra模块中的编译错误和代码质量问题。

更改内容
修复了 `libra/tests/command/log_test.rs` 中的 `LogArgs` 导入错误
解决了多个文件中的 clippy `uninlined_format_args` 警告  
将格式化字符串更新为直接变量插值形式

测试
所有单元测试通过
Clippy检查通过
编译无错误

相关Issue
Fixes #1227